### PR TITLE
Add feature and overlay parsing to scenes

### DIFF
--- a/engine/scene.py
+++ b/engine/scene.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import Optional, Dict, Any, List
 
 
 @dataclass
@@ -9,3 +9,5 @@ class Scene:
     id: Optional[str]
     background: Optional[str]
     mode: str = "simple"
+    features: Dict[str, Any] = field(default_factory=dict)
+    overlays: List[str] = field(default_factory=list)

--- a/engine/scene_manager.py
+++ b/engine/scene_manager.py
@@ -15,6 +15,9 @@ class SceneManager:
         self.config = config
         self.running = True
         self.current_scene = None
+        self.overlays = []
+        self.active_features = {}
+        self.scene_start_time = 0
         self.load_start_scene()
 
     # ------------------------------------------------------------------
@@ -27,6 +30,7 @@ class SceneManager:
             raise ValueError("Missing 'start_scene' in config")
 
         self.current_scene = self.load_scene(scene_path)
+        self.activate_scene(self.current_scene)
 
     def load_scene(self, path):
         """Read a YAML file and return a :class:`Scene` instance."""
@@ -41,7 +45,31 @@ class SceneManager:
             id=scene_data.get("id"),
             background=scene_data.get("background"),
             mode=scene_data.get("mode", "simple"),
+            features=scene_data.get("features", {}) or {},
+            overlays=scene_data.get("overlays", []) or [],
         )
+
+    def activate_scene(self, scene: Scene):
+        """Load assets and enable features for the given scene."""
+        self.overlays = []
+        self.active_features = scene.features or {}
+        self.scene_start_time = pygame.time.get_ticks()
+
+        music_path = self.active_features.get("music")
+        if music_path and os.path.exists(music_path):
+            try:
+                pygame.mixer.music.load(music_path)
+                pygame.mixer.music.play(-1)
+            except pygame.error as exc:
+                print(f"Failed to play music '{music_path}': {exc}")
+
+        for overlay_path in scene.overlays:
+            if os.path.exists(overlay_path):
+                try:
+                    image = pygame.image.load(overlay_path).convert_alpha()
+                    self.overlays.append(image)
+                except pygame.error as exc:
+                    print(f"Failed to load overlay '{overlay_path}': {exc}")
 
     def run(self):
         clock = pygame.time.Clock()
@@ -51,5 +79,21 @@ class SceneManager:
                     self.running = False
 
             self.screen.fill((30, 30, 30))  # Dark background
+
+            for overlay in self.overlays:
+                self.screen.blit(overlay, (0, 0))
+
+            if self.active_features.get("time_loop"):
+                duration = self.active_features.get("time_loop")
+                if isinstance(duration, bool):
+                    duration = 5000  # Default duration when True
+                try:
+                    duration = int(duration)
+                except (TypeError, ValueError):
+                    duration = 5000
+
+                if pygame.time.get_ticks() - self.scene_start_time >= duration:
+                    self.activate_scene(self.current_scene)
+
             pygame.display.flip()
             clock.tick(60)

--- a/game/scenes/intro.yaml
+++ b/game/scenes/intro.yaml
@@ -1,0 +1,10 @@
+scene:
+  id: intro
+  background: null
+  mode: simple
+  features:
+    music: assets/intro.mp3
+    time_loop: 5000
+    weather: rain
+  overlays:
+    - assets/game-engine.png


### PR DESCRIPTION
## Summary
- support optional scene `features` and `overlays`
- preload music and overlays when activating a scene
- restart scene if `time_loop` feature triggers
- include example scene with feature configuration

## Testing
- `pytest -q`