### PR TITLE
Add basic world and region loader

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,4 +3,5 @@ window:
   height: 600
   title: "game-engine"
 
-start_scene: "game/scenes/intro.yaml"
+start_world: "game/worlds/montreal.yaml"
+scenes_dir: "game/scenes"

--- a/engine/hotspot.py
+++ b/engine/hotspot.py
@@ -27,4 +27,7 @@ class Hotspot:
             manager.show_dialogue(self.target)
         elif self.action == "toggle_flag" and self.target:
             manager.toggle_flag(self.target)
+        elif self.action == "teleport" and self.target:
+            region, _, scene = self.target.partition(":")
+            manager.teleport(region, scene or None)
 

--- a/engine/world_loader.py
+++ b/engine/world_loader.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+import os
+import yaml
+
+@dataclass
+class Region:
+    """Simple region containing a list of scene identifiers."""
+    id: str
+    scenes: List[str] = field(default_factory=list)
+
+@dataclass
+class World:
+    """World data parsed from YAML."""
+    id: str
+    title: str
+    regions: Dict[str, Region] = field(default_factory=dict)
+
+class WorldLoader:
+    """Load a world YAML file defining regions and scenes."""
+
+    def __init__(self, path: str):
+        self.path = path
+        self.world = self.load_world(path)
+
+    def load_world(self, path: str) -> World:
+        if not os.path.exists(path):
+            raise FileNotFoundError(f"World file not found: {path}")
+        with open(path, "r") as fh:
+            data = yaml.safe_load(fh) or {}
+        world_data = data.get("world", {})
+        regions_data = world_data.get("regions", []) or []
+        regions: Dict[str, Region] = {}
+        for entry in regions_data:
+            if not isinstance(entry, dict):
+                continue
+            rid = entry.get("id")
+            scenes = entry.get("scenes", []) or []
+            if rid:
+                regions[rid] = Region(id=rid, scenes=list(scenes))
+        return World(
+            id=world_data.get("id", ""),
+            title=world_data.get("title", ""),
+            regions=regions,
+        )
+
+    def get_region(self, region_id: str) -> Optional[Region]:
+        return self.world.regions.get(region_id)
+
+    def first_region(self) -> Optional[Region]:
+        return next(iter(self.world.regions.values()), None)

--- a/game/scenes/balcon_secret.yaml
+++ b/game/scenes/balcon_secret.yaml
@@ -1,0 +1,8 @@
+scene:
+  id: balcon_secret
+  background: null
+hotspots:
+  - id: to_ruelle
+    area: [50,50,100,100]
+    action: open_scene
+    target: ruelle_portail

--- a/game/scenes/canal_start.yaml
+++ b/game/scenes/canal_start.yaml
@@ -1,0 +1,8 @@
+scene:
+  id: canal_start
+  background: null
+hotspots:
+  - id: to_tunnel
+    area: [50,50,100,100]
+    action: open_scene
+    target: tunnel_entry

--- a/game/scenes/ruelle_portail.yaml
+++ b/game/scenes/ruelle_portail.yaml
@@ -1,0 +1,12 @@
+scene:
+  id: ruelle_portail
+  background: null
+hotspots:
+  - id: to_balcon
+    area: [50,50,100,100]
+    action: open_scene
+    target: balcon_secret
+  - id: to_vieuxport
+    area: [200,50,100,100]
+    action: teleport
+    target: vieuxport:canal_start

--- a/game/scenes/tunnel_entry.yaml
+++ b/game/scenes/tunnel_entry.yaml
@@ -1,0 +1,12 @@
+scene:
+  id: tunnel_entry
+  background: null
+hotspots:
+  - id: back_to_canal
+    area: [50,50,100,100]
+    action: open_scene
+    target: canal_start
+  - id: to_mileend
+    area: [200,50,100,100]
+    action: teleport
+    target: mileend:ruelle_portail

--- a/game/worlds/montreal.yaml
+++ b/game/worlds/montreal.yaml
@@ -1,0 +1,12 @@
+world:
+  id: montreal
+  title: "Surreal Montreal"
+  regions:
+    - id: mileend
+      scenes:
+        - ruelle_portail
+        - balcon_secret
+    - id: vieuxport
+      scenes:
+        - canal_start
+        - tunnel_entry


### PR DESCRIPTION
## Summary
- parse world/region structure with new `WorldLoader`
- allow teleporting to another region via hotspots
- load a world and navigate scenes using scene IDs
- add Montreal demo world and extra scenes
- configure engine to start with a world file

## Testing
- `python -m py_compile engine/*.py main.py`