### PR TITLE
Add puzzle engine and manager

### DIFF
--- a/engine/puzzle_engine.py
+++ b/engine/puzzle_engine.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Type, Optional
+
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - allow tests without PyYAML
+    yaml = None
+
+try:
+    import pygame
+except Exception:  # pragma: no cover - allow running tests without pygame
+    pygame = None
+
+from .game_state import GameState
+
+
+@dataclass
+class PuzzleMeta:
+    """Metadata describing a puzzle entry."""
+
+    id: str
+    type: str
+    scene: str
+    solved: bool = False
+    description: str = ""
+
+
+class BasePuzzle:
+    """Base class for all puzzle implementations."""
+
+    def __init__(self, meta: PuzzleMeta, engine: "PuzzleEngine") -> None:
+        self.meta = meta
+        self.engine = engine
+
+    def start(self) -> None:
+        """Initialize puzzle state when activated."""
+        pass
+
+    def handle_event(self, event) -> None:  # pragma: no cover - UI only
+        if not pygame:
+            return
+
+    def render(self, screen) -> None:  # pragma: no cover - UI only
+        if not pygame:
+            return
+
+    def solve(self) -> None:
+        """Mark this puzzle as solved through the engine."""
+        self.engine.mark_solved(self.meta.id)
+
+
+class LogicPuzzle(BasePuzzle):
+    pass
+
+
+class MemoryPuzzle(BasePuzzle):
+    pass
+
+
+class SymbolPuzzle(BasePuzzle):
+    pass
+
+
+class PhysicsPuzzle(BasePuzzle):
+    pass
+
+
+class PuzzleEngine:
+    """Load puzzles from YAML and instantiate puzzle handlers."""
+
+    def __init__(self, state: GameState) -> None:
+        self.state = state
+        self.registry: Dict[str, PuzzleMeta] = {}
+        self.handlers: Dict[str, Type[BasePuzzle]] = {
+            "logic": LogicPuzzle,
+            "memory": MemoryPuzzle,
+            "symbol": SymbolPuzzle,
+            "physics": PhysicsPuzzle,
+        }
+
+    # ------------------------------------------------------------------
+    # Loading
+    # ------------------------------------------------------------------
+    def load_file(self, path: str) -> None:
+        """Load puzzle metadata from a YAML file."""
+        with open(path, "r") as fh:
+            if yaml:
+                data = yaml.safe_load(fh) or {}
+            else:  # pragma: no cover - fallback when PyYAML missing
+                import json
+
+                data = json.load(fh)
+        for entry in data.get("puzzles", []):
+            if not isinstance(entry, dict):
+                continue
+            puzzle = PuzzleMeta(
+                id=entry.get("id", ""),
+                type=entry.get("type", "logic"),
+                scene=entry.get("scene", ""),
+                solved=bool(entry.get("solved", False)),
+                description=entry.get("description", ""),
+            )
+            self.registry[puzzle.id] = puzzle
+
+    # ------------------------------------------------------------------
+    # Puzzle status
+    # ------------------------------------------------------------------
+    def mark_solved(self, puzzle_id: str) -> None:
+        """Set the solved flag for ``puzzle_id`` in :class:`GameState`."""
+        self.state.set_flag(f"puzzle_{puzzle_id}", True)
+        self.state.save()
+
+    def is_solved(self, puzzle_id: str) -> bool:
+        """Return True if ``puzzle_id`` is marked solved."""
+        return self.state.get_flag(f"puzzle_{puzzle_id}")
+
+    # ------------------------------------------------------------------
+    # Factory
+    # ------------------------------------------------------------------
+    def create(self, puzzle_id: str) -> Optional[BasePuzzle]:
+        meta = self.registry.get(puzzle_id)
+        if not meta:
+            return None
+        cls = self.handlers.get(meta.type, BasePuzzle)
+        return cls(meta, self)

--- a/engine/puzzle_manager.py
+++ b/engine/puzzle_manager.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Optional
+
+try:
+    import pygame
+except Exception:  # pragma: no cover - allow running tests without pygame
+    pygame = None
+
+from .game_state import GameState
+from .puzzle_engine import PuzzleEngine, BasePuzzle
+
+
+class PuzzleManager:
+    """Handle puzzle lifecycle and rendering."""
+
+    def __init__(self, state: GameState) -> None:
+        self.state = state
+        self.engine = PuzzleEngine(state)
+        self.active: Optional[BasePuzzle] = None
+        self.active_id: Optional[str] = None
+
+    def load_file(self, path: str) -> None:
+        """Load puzzle registry from ``path``."""
+        self.engine.load_file(path)
+
+    # ------------------------------------------------------------------
+    # Activation
+    # ------------------------------------------------------------------
+    def start(self, puzzle_id: str) -> None:
+        puzzle = self.engine.create(puzzle_id)
+        if not puzzle:
+            return
+        self.active = puzzle
+        self.active_id = puzzle_id
+        puzzle.start()
+
+    def complete_puzzle(self) -> None:
+        if self.active_id:
+            self.engine.mark_solved(self.active_id)
+        self.active = None
+        self.active_id = None
+
+    # ------------------------------------------------------------------
+    # Interaction helpers
+    # ------------------------------------------------------------------
+    def handle_event(self, event) -> None:  # pragma: no cover - UI only
+        if self.active:
+            self.active.handle_event(event)
+
+    def draw(self, screen) -> None:  # pragma: no cover - UI only
+        if self.active:
+            self.active.render(screen)

--- a/game/puzzles.yaml
+++ b/game/puzzles.yaml
@@ -1,0 +1,6 @@
+puzzles:
+  - id: "sun_mirror"
+    type: "light_reflection"
+    scene: "garden_observatory"
+    solved: false
+    description: "Reflect sunlight to open the sealed gate"

--- a/tests/test_puzzle_engine.py
+++ b/tests/test_puzzle_engine.py
@@ -1,0 +1,53 @@
+import os
+import sys
+import json
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from engine.puzzle_manager import PuzzleManager
+from engine.game_state import GameState
+
+
+def test_load_puzzles(tmp_path):
+    data = {
+        "puzzles": [
+            {
+                "id": "sun_mirror",
+                "type": "logic",
+                "scene": "garden_observatory",
+                "solved": False,
+                "description": "Reflect sunlight to open the sealed gate",
+            }
+        ]
+    }
+    path = tmp_path / "puzzles.json"
+    with open(path, "w") as fh:
+        json.dump(data, fh)
+
+    state = GameState(save_path=str(tmp_path / "save.json"))
+    manager = PuzzleManager(state)
+    manager.load_file(str(path))
+
+    assert "sun_mirror" in manager.engine.registry
+    puzzle = manager.engine.registry["sun_mirror"]
+    assert puzzle.description.startswith("Reflect")
+
+
+def test_mark_solved(tmp_path):
+    data = {
+        "puzzles": [
+            {"id": "mirror", "type": "logic", "scene": "obs", "solved": False}
+        ]
+    }
+    path = tmp_path / "puzzles.json"
+    with open(path, "w") as fh:
+        json.dump(data, fh)
+
+    state = GameState(save_path=str(tmp_path / "save.json"))
+    manager = PuzzleManager(state)
+    manager.load_file(str(path))
+
+    manager.start("mirror")
+    manager.complete_puzzle()
+
+    assert state.get_flag("puzzle_mirror") is True


### PR DESCRIPTION
## Summary
- implement `PuzzleEngine` with pluggable puzzle classes
- add `PuzzleManager` to launch and complete puzzles
- include default `game/puzzles.yaml` registry
- test loading puzzles and tracking completion

## Testing
- `pytest -q`