### PR TITLE
Implement world metadata loading

### DIFF
--- a/game/worlds/montreal.yaml
+++ b/game/worlds/montreal.yaml
@@ -1,6 +1,11 @@
 world:
   id: montreal
   title: "Surreal Montreal"
+  start_region: mileend
+  global_music: assets/music/montreal_theme.ogg
+  loop_time: 6000
+  gravity: 9.8
+  weather: rain
   regions:
     - id: mileend
       scenes:

--- a/tests/test_world_manager.py
+++ b/tests/test_world_manager.py
@@ -12,8 +12,15 @@ from engine.world_manager import WorldManager
 def test_world_loading():
     wm = WorldManager("game/worlds/montreal.yaml")
     assert wm.world.id == "montreal"
+    assert wm.world.start_region == "mileend"
+    assert wm.world.global_music == "assets/music/montreal_theme.ogg"
+    assert wm.world.loop_time == 6000
+    assert wm.world.gravity == 9.8
+    assert wm.world.weather == "rain"
     assert "mileend" in wm.world.regions
-    assert wm.current_region() is None or wm.current_region().id in wm.world.regions
+    assert wm.current_region() is not None
+    assert wm.current_region().id == "mileend"
+    assert wm.current_scene() == "ruelle_portail"
 
 
 def test_save_load_state(tmp_path):
@@ -25,4 +32,5 @@ def test_save_load_state(tmp_path):
     new_wm = WorldManager("game/worlds/montreal.yaml")
     new_wm.load_state(str(path))
     assert new_wm.state.current_region == "vieuxport"
+    assert new_wm.current_scene() == "canal_start"
 


### PR DESCRIPTION
## Summary
- extend world metadata in `montreal.yaml`
- verify metadata parsing in `tests/test_world_manager.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68602f4478848322af583a35b70f4322