### PR TITLE
Add unit tests for managers

### DIFF
--- a/tests/test_asset_manager.py
+++ b/tests/test_asset_manager.py
@@ -60,3 +60,25 @@ def test_getters_with_stub(monkeypatch):
     manager.get_music("music.mp3")
     assert manager.music["music.mp3"] == "music.mp3"
 
+
+def test_load_real_files(monkeypatch, tmp_path):
+    monkeypatch.setitem(sys.modules, "pygame", DummyPygame)
+    from engine.asset_manager import AssetManager
+
+    monkeypatch.setattr("engine.asset_manager.pygame", DummyPygame)
+
+    image_path = tmp_path / "image.png"
+    audio_path = tmp_path / "sound.ogg"
+    image_path.write_bytes(b"img")
+    audio_path.write_bytes(b"aud")
+
+    manager = AssetManager()
+
+    surf = manager.get_image(str(image_path))
+    assert surf is not None
+    assert manager.get_image(str(image_path)) is surf
+
+    music = manager.get_music(str(audio_path))
+    assert music == str(audio_path)
+    assert manager.get_music(str(audio_path)) == str(audio_path)
+

--- a/tests/test_world_manager.py
+++ b/tests/test_world_manager.py
@@ -30,3 +30,25 @@ def test_save_load_state(tmp_path):
     assert new_wm.state.current_region == "vieuxport"
     assert new_wm.current_scene() == "canal_start"
 
+
+def test_load_custom_world_metadata(tmp_path):
+    yaml_data = """
+    world:
+      id: custom
+      title: "Custom World"
+      start_region: alpha
+      regions:
+        - id: alpha
+          scenes: [start]
+    """
+    path = tmp_path / "world.yaml"
+    path.write_text(yaml_data)
+
+    wm = WorldManager(str(path))
+    assert wm.world.id == "custom"
+    assert wm.world.title == "Custom World"
+    assert wm.world.start_region == "alpha"
+    assert list(wm.world.regions.keys()) == ["alpha"]
+    assert wm.current_region().id == "alpha"
+    assert wm.current_scene() == "start"
+


### PR DESCRIPTION
## Summary
- cover world metadata loading
- exercise AssetManager with real files

## Testing
- `pytest -q`