### PR TITLE
Update docs for world and asset managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,40 @@ events:
     flag: door_closed
 ```
 
+### 🗺 World Manager
+
+Worlds are described in YAML files that list regions and scenes. This new format
+includes metadata like ``title`` and ``start_region``. Load a world with
+``WorldManager``:
+
+```yaml
+world:
+  id: montreal
+  title: "Surreal Montreal"
+  start_region: mileend
+  regions:
+    - id: mileend
+      scenes: [ruelle_portail]
+```
+
+```python
+from engine.world_manager import WorldManager
+wm = WorldManager("game/worlds/montreal.yaml")
+print(wm.current_scene())
+```
+
+### 🎨 Asset Manager
+
+Use ``AssetManager`` to cache images and music referenced by scenes:
+
+```python
+from engine.asset_manager import AssetManager
+assets = AssetManager()
+scene = ...  # a Scene object
+assets.preload_scene(scene)
+background = assets.get_image(scene.background)
+```
+
 ---
 
 ## 🤝 Contributing

--- a/change-log.md
+++ b/change-log.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
   interactions.
 - Added ``TimelineEngine`` to schedule delay-based events that modify ``GameState``.
 - Added ``WorldManager`` to handle world loading and state management.
+- Added ``AssetManager`` for caching images and music.
+- Worlds now use a YAML format loaded by ``WorldManager``.
 
 ## [0.1.0] - 2024-01-01
 


### PR DESCRIPTION
## Summary
- document usage of `WorldManager` and `AssetManager`
- describe YAML world format
- update change log

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687280acb9f08322acae707445ef79a3