### PR TITLE
Improve GameState API with debugging and reset features

### DIFF
--- a/tests/test_gamestate.py
+++ b/tests/test_gamestate.py
@@ -14,21 +14,33 @@ def test_flag_management(tmp_path):
     state.toggle_flag("door_opened")
     assert state.get_flag("door_opened") is False
 
-    state.set_variable("code", "1234")
-    assert state.get_variable("code") == "1234"
+    state.set_var("code", "1234")
+    assert state.get_var("code") == "1234"
+    assert state.get_var("missing") is None
 
     state.add_item("rusty_key")
     assert state.has_item("rusty_key") is True
+    assert state.list_inventory() == ["rusty_key"]
+    state.remove_item("rusty_key")
+    assert state.has_item("rusty_key") is False
+    assert state.list_inventory() == []
 
     state.set_scene("garden")
     assert state.get_scene() == "garden"
+
+    state.clear()
+    assert state.get_flag("door_opened") is False
+    assert state.flags == {}
+    assert state.variables == {}
+    assert state.inventory == []
+    assert state.get_scene() == ""
 
 
 def test_save_load(tmp_path):
     path = tmp_path / "save.json"
     state = GameState(save_path=str(path))
     state.set_flag("key_found", True)
-    state.set_variable("puzzle_code", 7391)
+    state.set_var("puzzle_code", 7391)
     state.add_item("key")
     state.set_scene("intro")
     state.clues.append("note")
@@ -38,8 +50,9 @@ def test_save_load(tmp_path):
     new_state = GameState(save_path=str(path))
     new_state.load()
     assert new_state.get_flag("key_found") is True
-    assert new_state.get_variable("puzzle_code") == 7391
+    assert new_state.get_var("puzzle_code") == 7391
     assert new_state.has_item("key") is True
+    assert new_state.list_inventory() == ["key"]
     assert new_state.get_scene() == "intro"
     assert "note" in new_state.clues
     assert "intro" in new_state.unlocked_scenes
@@ -53,3 +66,13 @@ def test_check_condition():
     assert state.check_condition(None) is True
     state.toggle_flag("seen")
     assert state.check_condition("!seen") is True
+
+
+def test_export_debug(capsys):
+    state = GameState()
+    state.set_flag("debug", True)
+    state.set_var("value", 42)
+    state.export_debug()
+    captured = capsys.readouterr().out
+    assert '"debug": true' in captured
+    assert '"value": 42' in captured


### PR DESCRIPTION
## Summary
- extend GameState with flexible variable methods
- add inventory helpers and clearing/debug utilities
- update tests for new API

## Testing
- `pytest -q`
