### PR TITLE
Add world manager with metadata helpers

### DIFF
--- a/engine/world_manager.py
+++ b/engine/world_manager.py
@@ -40,26 +40,31 @@ class WorldState:
 
 
 class WorldManager:
-    """Load world data and keep track of the current region and scene."""
+    """High-level world management.
 
-    def __init__(self, path_or_id: str, worlds_dir: str = "game/worlds"):
+    The manager loads a YAML world definition and exposes convenience
+    accessors for world metadata, regions and entry scenes.  It also
+    maintains the currently active region and scene for compatibility
+    with the rest of the engine.
+    """
+
+    def __init__(self, path_or_id: str | None = None, worlds_dir: str = "game/worlds"):
         self.worlds_dir = worlds_dir
-        if os.path.exists(path_or_id):
-            self.path = path_or_id
-        else:
-            self.path = os.path.join(self.worlds_dir, f"{path_or_id}.yaml")
-        self.world = self._load_world_file(self.path)
-        self.state = WorldState(
-            current_region=self.world.start_region,
-            current_scene=None,
-        )
-        if self.state.current_region:
-            region = self.world.regions.get(self.state.current_region)
-            if region:
-                self.state.current_scene = (
-                    region.entry_scene
-                    or (region.scenes[0] if region.scenes else None)
-                )
+
+        # new attributes used by the simplified API
+        self.world_id: str = ""
+        self.world_data: dict = {}
+        self.world_metadata: dict = {}
+        self.current_region_id: str = ""
+        self.region_data: Dict[str, dict] = {}
+
+        # legacy attributes retained for backwards compatibility
+        self.path: str | None = None
+        self.world: World | None = None
+        self.state: WorldState | None = None
+
+        if path_or_id:
+            self.load_world(path_or_id)
 
     # ------------------------------------------------------------------
     # Loading helpers
@@ -69,9 +74,16 @@ class WorldManager:
             raise FileNotFoundError(f"World file not found: {path}")
         with open(path, "r") as fh:
             data = yaml.safe_load(fh) or {}
-        world_data = data.get("world", {})
+        world_data = data.get("world", {}) or {}
+
+        # expose raw data and metadata for the simplified API
+        self.world_data = data
+        self.world_metadata = {k: v for k, v in world_data.items() if k != "regions"}
+        self.world_id = world_data.get("id", "")
+
         regions_data = world_data.get("regions", []) or []
         regions: Dict[str, Region] = {}
+        self.region_data = {}
         for entry in regions_data:
             if not isinstance(entry, dict):
                 continue
@@ -84,8 +96,10 @@ class WorldManager:
                     entry_scene=entry.get("entry_scene"),
                     scenes=list(scenes),
                 )
+                self.region_data[rid] = entry
+
         return World(
-            id=world_data.get("id", ""),
+            id=self.world_id,
             title=world_data.get("title", ""),
             start_region=world_data.get("start_region"),
             global_music=world_data.get("global_music"),
@@ -95,15 +109,22 @@ class WorldManager:
             regions=regions,
         )
 
-    def load_world(self, world_id: str) -> None:
-        """Load a new world given its identifier."""
-        path = os.path.join(self.worlds_dir, f"{world_id}.yaml")
-        self.path = path
-        self.world = self._load_world_file(path)
-        self.state.current_region = self.world.start_region
-        self.state.current_scene = None
-        if self.state.current_region:
-            region = self.world.regions.get(self.state.current_region)
+    def load_world(self, path: str) -> None:
+        """Load a new world from a file path or identifier."""
+        if os.path.exists(path):
+            file_path = path
+        else:
+            file_path = os.path.join(self.worlds_dir, f"{path}.yaml")
+
+        self.path = file_path
+        self.world = self._load_world_file(file_path)
+
+        start_region = self.world.start_region
+        self.current_region_id = start_region or ""
+        self.state = WorldState(current_region=start_region, current_scene=None)
+
+        if start_region:
+            region = self.world.regions.get(start_region)
             if region:
                 self.state.current_scene = (
                     region.entry_scene
@@ -125,25 +146,60 @@ class WorldManager:
         """Return the identifier of the active region."""
         return self.state.current_region
 
-    def get_start_scene(self) -> Optional[str]:
-        """Return the starting scene for the current world."""
-        if not self.world.start_region:
+    # ------------------------------------------------------------------
+    # Simplified API accessors
+    # ------------------------------------------------------------------
+
+    def get_start_region(self) -> str:
+        """Return the ID of the start region for the loaded world."""
+        return self.world_metadata.get("start_region", "")
+
+    def get_start_scene(self) -> str | None:
+        """Return the entry scene for the start region, if any."""
+        start_region = self.get_start_region()
+        if not start_region:
             return None
-        region = self.world.regions.get(self.world.start_region)
+        region = self.region_data.get(start_region)
         if not region:
             return None
-        return region.entry_scene or (region.scenes[0] if region.scenes else None)
+        entry = region.get("entry_scene")
+        if entry:
+            return entry
+        scenes = region.get("scenes") or []
+        return scenes[0] if scenes else None
+
+    def get_regions(self) -> List[dict]:
+        """Return a list of region dictionaries."""
+        return list(self.region_data.values())
+
+    def get_region(self, region_id: str) -> dict | None:
+        """Return a specific region dictionary."""
+        return self.region_data.get(region_id)
+
+    def set_region(self, region_id: str) -> None:
+        """Set the current active region if it exists."""
+        if region_id in self.region_data:
+            self.current_region_id = region_id
+            self.state.current_region = region_id
+
+    def get_current_region_id(self) -> str:
+        """Return the currently active region identifier."""
+        return self.current_region_id
+
+    def get_current_entry_scene(self) -> str | None:
+        """Return the entry scene for the current region, if any."""
+        region = self.region_data.get(self.current_region_id)
+        if not region:
+            return None
+        entry = region.get("entry_scene")
+        if entry:
+            return entry
+        scenes = region.get("scenes") or []
+        return scenes[0] if scenes else None
 
     def get_world_metadata(self) -> Dict[str, Optional[str]]:
         """Return key metadata about the loaded world."""
-        return {
-            "id": self.world.id,
-            "title": self.world.title,
-            "global_music": self.world.global_music,
-            "loop_time": self.world.loop_time,
-            "gravity": self.world.gravity,
-            "weather": self.world.weather,
-        }
+        return dict(self.world_metadata)
 
     # ------------------------------------------------------------------
     # State Management


### PR DESCRIPTION
## Summary
- expand `WorldManager` to expose simplified API
- keep compatibility with previous behaviour
- parse world metadata and region info for quick access

## Testing
- `pytest -q`