### PR TITLE
Implement robust asset manager

### DIFF
--- a/engine/asset_manager.py
+++ b/engine/asset_manager.py
@@ -1,8 +1,10 @@
-import os
-import logging
-from typing import Dict, Optional
+from __future__ import annotations
 
-try:
+import logging
+import os
+from typing import Dict, List, Optional
+
+try:  # pragma: no cover - allow running tests without pygame
     import pygame
 except Exception:  # pragma: no cover - allow running tests without pygame
     pygame = None
@@ -13,94 +15,160 @@ logger = logging.getLogger(__name__)
 
 
 class AssetManager:
-    """Load and cache images and music files."""
+    """Load and cache game assets with smart caching and fallbacks."""
 
-    def __init__(self) -> None:
-        self.images: Dict[str, "pygame.Surface"] = {}
-        self.music: Dict[str, str] = {}
-        self.sounds: Dict[str, "pygame.mixer.Sound"] = {}
+    def __init__(self, base_path: str = "assets/", search_paths: Optional[List[str]] = None) -> None:
+        self.base_path = base_path
+        self.search_paths: List[str] = search_paths or []
+        self.image_cache: Dict[str, "pygame.Surface"] = {}
+        self.music_cache: Dict[str, str] = {}
+        self.sound_cache: Dict[str, "pygame.mixer.Sound"] = {}
+
+        # backward compatible attribute names
+        self.images = self.image_cache
+        self.music = self.music_cache
+        self.sounds = self.sound_cache
+
+    # ------------------------------------------------------------------
+    # Path helpers
+    # ------------------------------------------------------------------
+    def _resolve_path(self, path: str) -> str:
+        if os.path.isabs(path):
+            if os.path.exists(path):
+                return path
+        else:
+            candidate = os.path.join(self.base_path, path)
+            if os.path.exists(candidate):
+                return candidate
+        for root in self.search_paths:
+            candidate = os.path.join(root, path)
+            if os.path.exists(candidate):
+                return candidate
+        return os.path.join(self.base_path, path)
+
+    def _placeholder_image(self) -> Optional["pygame.Surface"]:
+        if not pygame:
+            return None
+        surf = pygame.Surface((1, 1), pygame.SRCALPHA)
+        surf.fill((255, 0, 255, 255))
+        return surf
 
     # ------------------------------------------------------------------
     # Image helpers
     # ------------------------------------------------------------------
     def get_image(self, path: str) -> Optional["pygame.Surface"]:
-        """Return a cached :class:`pygame.Surface` for ``path``."""
-        if path in self.images:
-            return self.images[path]
+        key = os.path.normpath(path)
+        if key in self.image_cache:
+            return self.image_cache[key]
+
+        resolved = self._resolve_path(path)
         if not pygame:
-            logger.info("pygame not available, skipping image load: %s", path)
+            logger.info("pygame not available, skipping image load: %s", resolved)
             return None
-        if not os.path.exists(path):
-            logger.warning("Image not found: %s", path)
-            return None
+        if not os.path.exists(resolved):
+            logger.warning("Image not found: %s", resolved)
+            image = self._placeholder_image()
+            if image:
+                self.image_cache[key] = image
+            return image
         try:
-            image = pygame.image.load(path).convert_alpha()
+            image = pygame.image.load(resolved).convert_alpha()
         except Exception as exc:  # pragma: no cover - only when pygame fails
-            logger.error("Failed to load image '%s': %s", path, exc)
-            return None
-        self.images[path] = image
+            logger.error("Failed to load image '%s': %s", resolved, exc)
+            image = self._placeholder_image()
+        if image:
+            self.image_cache[key] = image
         return image
 
     # ------------------------------------------------------------------
     # Music helpers
     # ------------------------------------------------------------------
     def get_music(self, path: str) -> Optional[str]:
-        """Preload a music file and cache its path."""
-        if path in self.music:
-            return self.music[path]
+        key = os.path.normpath(path)
+        if key in self.music_cache:
+            return self.music_cache[key]
+
+        resolved = self._resolve_path(path)
         if not pygame:
-            logger.info("pygame not available, skipping music load: %s", path)
-            self.music[path] = path
-            return path
-        if not os.path.exists(path):
-            logger.warning("Music not found: %s", path)
-            return None
+            logger.info("pygame not available, skipping music load: %s", resolved)
+            self.music_cache[key] = resolved
+            return resolved
+        if not os.path.exists(resolved):
+            logger.warning("Music not found: %s", resolved)
+            self.music_cache[key] = resolved
+            return resolved
         try:
-            pygame.mixer.music.load(path)
+            pygame.mixer.music.load(resolved)
         except Exception as exc:  # pragma: no cover - only when pygame fails
-            logger.error("Failed to load music '%s': %s", path, exc)
-            return None
-        self.music[path] = path
-        return path
+            logger.error("Failed to load music '%s': %s", resolved, exc)
+        self.music_cache[key] = resolved
+        return resolved
 
     # ------------------------------------------------------------------
     # Sound effect helpers
     # ------------------------------------------------------------------
     def get_sound(self, path: str) -> Optional["pygame.mixer.Sound"]:
-        """Load a sound effect from ``path`` and cache it."""
-        if path in self.sounds:
-            return self.sounds[path]
+        key = os.path.normpath(path)
+        if key in self.sound_cache:
+            return self.sound_cache[key]
+
+        resolved = self._resolve_path(path)
         if not pygame:
-            logger.info("pygame not available, skipping sound load: %s", path)
+            logger.info("pygame not available, skipping sound load: %s", resolved)
             return None
-        if not os.path.exists(path):
-            logger.warning("Sound not found: %s", path)
+        if not os.path.exists(resolved):
+            logger.warning("Sound not found: %s", resolved)
             return None
         try:
-            sound = pygame.mixer.Sound(path)
+            sound = pygame.mixer.Sound(resolved)
         except Exception as exc:  # pragma: no cover - only when pygame fails
-            logger.error("Failed to load sound '%s': %s", path, exc)
+            logger.error("Failed to load sound '%s': %s", resolved, exc)
             return None
-        self.sounds[path] = sound
+        self.sound_cache[key] = sound
         return sound
 
     # ------------------------------------------------------------------
     # Scene helpers
     # ------------------------------------------------------------------
-    def preload_scene(self, scene: Scene) -> None:
-        """Load assets referenced by ``scene`` into the cache."""
-        if scene.background:
-            self.get_image(scene.background)
-        for overlay in scene.overlays:
+    def preload_scene_assets(self, scene_data: Scene | Dict) -> None:
+        if isinstance(scene_data, dict):
+            scene_dict = scene_data
+        else:
+            scene_dict = {
+                "background": getattr(scene_data, "background", None),
+                "overlays": getattr(scene_data, "overlays", []),
+                "features": getattr(scene_data, "features", {}) or {},
+                "id": getattr(scene_data, "id", None),
+            }
+        if scene_dict.get("background"):
+            self.get_image(scene_dict["background"])
+        for overlay in scene_dict.get("overlays", []) or []:
             self.get_image(overlay)
-        music_path = scene.features.get("music") if scene.features else None
+        features = scene_dict.get("features") or {}
+        music_path = features.get("music")
         if music_path:
             self.get_music(music_path)
-        if scene.features:
-            sound_path = scene.features.get("sound")
-            if sound_path:
-                self.get_sound(sound_path)
-            for snd in scene.features.get("sounds", []):
-                self.get_sound(snd)
+        sound_path = features.get("sound")
+        if sound_path:
+            self.get_sound(sound_path)
+        for snd in features.get("sounds", []):
+            self.get_sound(snd)
+        logger.debug("Preloaded assets for scene: %s", scene_dict.get("id"))
 
+    # backward compatibility
+    preload_scene = preload_scene_assets
 
+    # ------------------------------------------------------------------
+    # Cache management
+    # ------------------------------------------------------------------
+    def clear_cache(self, category: Optional[str] = None) -> None:
+        if category is None:
+            self.image_cache.clear()
+            self.music_cache.clear()
+            self.sound_cache.clear()
+        elif category in {"images", "image"}:
+            self.image_cache.clear()
+        elif category in {"music", "musics"}:
+            self.music_cache.clear()
+        elif category in {"sounds", "sound"}:
+            self.sound_cache.clear()

--- a/tests/test_asset_manager.py
+++ b/tests/test_asset_manager.py
@@ -42,7 +42,7 @@ def test_preload_without_pygame(monkeypatch, caplog):
     with caplog.at_level(logging.INFO):
         manager.preload_scene(scene)
     assert manager.images == {}
-    assert manager.music == {"song.mp3": "song.mp3"}
+    assert manager.music == {"song.mp3": os.path.join(manager.base_path, "song.mp3")}
     assert "pygame not available" in caplog.text
 
 
@@ -58,7 +58,7 @@ def test_getters_with_stub(monkeypatch):
     assert surf is not None
     assert manager.get_image("img.png") is surf
     manager.get_music("music.mp3")
-    assert manager.music["music.mp3"] == "music.mp3"
+    assert manager.music["music.mp3"] == os.path.join(manager.base_path, "music.mp3")
 
 
 def test_load_real_files(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- redesign `AssetManager` with caching dictionaries and base path support
- handle asset lookup with fallbacks and placeholder image
- keep backwards compatibility
- adjust tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872bdf2dbd083228eafb0a8faed9251