### PR TITLE
Add modular PuzzleEngine framework

### DIFF
--- a/engine/puzzle_manager.py
+++ b/engine/puzzle_manager.py
@@ -8,16 +8,28 @@ except Exception:  # pragma: no cover - allow running tests without pygame
     pygame = None
 
 from .game_state import GameState
-from .puzzle_engine import PuzzleEngine, BasePuzzle
+from .puzzle_engine import PuzzleEngine, PuzzleBase
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - type hints only
+    from .ui_overlay import UIOverlay
+    from .scene_manager import SceneManager
 
 
 class PuzzleManager:
     """Handle puzzle lifecycle and rendering."""
 
-    def __init__(self, state: GameState) -> None:
+    def __init__(
+        self,
+        state: GameState,
+        ui_overlay: "UIOverlay | None" = None,
+        scene_manager: "SceneManager | None" = None,
+    ) -> None:
         self.state = state
-        self.engine = PuzzleEngine(state)
-        self.active: Optional[BasePuzzle] = None
+        self.engine = PuzzleEngine(
+            state, ui_overlay=ui_overlay, scene_manager=scene_manager
+        )
+        self.active: Optional[PuzzleBase] = None
         self.active_id: Optional[str] = None
 
     def load_file(self, path: str) -> None:
@@ -33,12 +45,14 @@ class PuzzleManager:
             return
         self.active = puzzle
         self.active_id = puzzle_id
+        self.engine.active_puzzle = puzzle
         puzzle.start()
 
     def complete_puzzle(self) -> None:
         if self.active_id:
             self.engine.mark_solved(self.active_id)
         self.active = None
+        self.engine.active_puzzle = None
         self.active_id = None
 
     # ------------------------------------------------------------------
@@ -46,8 +60,12 @@ class PuzzleManager:
     # ------------------------------------------------------------------
     def handle_event(self, event) -> None:  # pragma: no cover - UI only
         if self.active:
-            self.active.handle_event(event)
+            self.active.handle_input(event)
 
     def draw(self, screen) -> None:  # pragma: no cover - UI only
         if self.active:
             self.active.render(screen)
+
+    def update(self) -> None:
+        if self.active:
+            self.active.update()


### PR DESCRIPTION
## Summary
- overhaul puzzle engine with `PuzzleBase` class and starter puzzle types
- support YAML puzzle metadata with `condition`, `data`, and `on_solve`
- handle active puzzle updates, rendering and input
- expose puzzle manager helpers for new engine

## Testing
- `pytest -q`