### PR TITLE
Add robust TimelineEngine with loop support

### DIFF
--- a/engine/timeline_engine.py
+++ b/engine/timeline_engine.py
@@ -1,76 +1,187 @@
-from dataclasses import dataclass
+from __future__ import annotations
+
+from dataclasses import dataclass, field
 from typing import List, Optional, Dict
 
 from .game_state import GameState
 
+if False:  # pragma: no cover - for type checkers
+    from .scene_manager import SceneManager
+
 
 @dataclass
 class TimelineEvent:
-    """Single scheduled event."""
+    """Represents a single scheduled event."""
 
+    id: str
     trigger: str
-    time: int  # milliseconds
+    time: float
     action: str
-    flag: Optional[str] = None
+    params: Dict[str, object] = field(default_factory=dict)
+    condition: Optional[str] = None
     scene: Optional[str] = None
-    scheduled_at: int = 0
+    scheduled_at: float = 0.0
+    triggered: bool = False
+
+    def is_ready(self, current_time: float, state: GameState) -> bool:
+        """Return ``True`` if the event should fire."""
+        if self.triggered:
+            return False
+        if self.trigger == "delay":
+            return current_time - self.scheduled_at >= self.time
+        if self.trigger == "condition":
+            if not state.check_condition(self.condition):
+                return False
+            return current_time - self.scheduled_at >= self.time
+        if self.trigger == "scene":
+            return True
+        return False
+
+    def execute(self, state: GameState, manager: "SceneManager | None") -> None:
+        """Carry out the event action."""
+        if self.action == "set_flag":
+            flag = self.params.get("flag")
+            if isinstance(flag, str):
+                state.set_flag(flag, True)
+                state.save()
+        elif self.action == "toggle_flag":
+            flag = self.params.get("flag")
+            if isinstance(flag, str):
+                state.toggle_flag(flag)
+                state.save()
+        elif self.action == "show_dialogue" and manager:
+            text = self.params.get("text")
+            if isinstance(text, str) and manager.dialogue_engine:
+                manager.dialogue_engine.start(text)
+        elif self.action == "goto_scene" and manager:
+            target = self.params.get("scene")
+            if isinstance(target, str):
+                manager.open_scene(target)
+        # Additional actions can be plugged in here
 
 
 class TimelineEngine:
-    """Manage time-based events for scenes or globally."""
+    """Manage time-based events and optional looping timelines."""
 
-    def __init__(self, state: GameState):
-        self.state = state
+    def __init__(self, state: GameState, scene_manager: "SceneManager | None" = None) -> None:
         self.events: List[TimelineEvent] = []
+        self.elapsed_time: float = 0.0
+        self.loop_enabled: bool = False
+        self.loop_duration: float = 0.0
+        self.game_state = state
+        self.scene_manager = scene_manager
+        self._last_tick: int = 0
 
     # ------------------------------------------------------------------
-    # Scheduling
+    # Scheduling helpers
     # ------------------------------------------------------------------
-    def add_events(self, entries: List[Dict], current_ticks: int, scene: Optional[str] = None) -> None:
-        """Load events from a list of dictionaries."""
+    def load_events(self, event_data: List[Dict[str, object]]) -> None:
+        """Load events from a raw data list."""
+        for entry in event_data:
+            if not isinstance(entry, dict):
+                continue
+            trigger = entry.get("trigger", "delay")
+            action = entry.get("action", "")
+            params = entry.get("params", {}) or {}
+            time_val = entry.get("time", entry.get("delay", 0))
+            try:
+                delay = float(time_val)
+            except (TypeError, ValueError):
+                delay = 0.0
+            event = TimelineEvent(
+                id=str(entry.get("id", "")),
+                trigger=str(trigger),
+                time=delay,
+                action=str(action),
+                params=params,
+                condition=entry.get("condition"),
+            )
+            self.add_event(event)
+
+    def add_event(self, event: TimelineEvent, scene: Optional[str] = None) -> None:
+        """Add a :class:`TimelineEvent` instance."""
+        event.scene = scene
+        event.scheduled_at = self.elapsed_time
+        self.events.append(event)
+
+    # ------------------------------------------------------------------
+    # Compatibility loader
+    # ------------------------------------------------------------------
+    def add_events(self, entries: List[Dict[str, object]], current_ticks: int, scene: Optional[str] = None) -> None:
+        """Backwards compatible loader using ticks."""
+        self._sync_ticks(current_ticks)
         for entry in entries:
             if not isinstance(entry, dict):
                 continue
-            trigger = entry.get("trigger")
-            time_val = entry.get("time", 0)
-            action = entry.get("action")
-            flag = entry.get("flag")
-            if trigger != "delay" or action is None:
-                continue
+            trigger = entry.get("trigger", "delay")
+            action = entry.get("action", "")
+            time_val = entry.get("time", entry.get("delay", 0))
+            params: Dict[str, object] = {}
+            if entry.get("flag"):
+                params["flag"] = entry.get("flag")
+            if entry.get("params"):
+                params.update(entry.get("params"))
             try:
-                delay_ms = int(float(time_val) * 1000)
+                delay = float(time_val)
             except (TypeError, ValueError):
-                delay_ms = 0
-            self.events.append(
-                TimelineEvent(
-                    trigger="delay",
-                    time=delay_ms,
-                    action=action,
-                    flag=flag,
-                    scene=scene,
-                    scheduled_at=current_ticks,
-                )
+                delay = 0.0
+            ev = TimelineEvent(
+                id=str(entry.get("id", "")),
+                trigger=str(trigger),
+                time=delay,
+                action=str(action),
+                params=params,
+                condition=entry.get("condition"),
             )
+            self.add_event(ev, scene)
 
     # ------------------------------------------------------------------
     # Update
     # ------------------------------------------------------------------
     def update(self, current_ticks: int, current_scene: Optional[str] = None) -> None:
-        """Trigger events whose timers have elapsed."""
+        """Advance timers and fire ready events."""
+        self._sync_ticks(current_ticks)
         to_remove: List[TimelineEvent] = []
         for event in self.events:
-            if event.scene and event.scene != current_scene:
+            if event.scene and current_scene and event.scene != current_scene:
                 continue
-            if event.trigger == "delay" and current_ticks - event.scheduled_at >= event.time:
-                self._execute(event)
-                to_remove.append(event)
+            if event.is_ready(self.elapsed_time, self.game_state):
+                self.trigger_event(event)
+                if self.loop_enabled:
+                    event.triggered = True
+                    event.scheduled_at = self.elapsed_time
+                else:
+                    to_remove.append(event)
         for ev in to_remove:
             self.events.remove(ev)
+        if self.loop_enabled and self.loop_duration > 0.0:
+            if self.elapsed_time >= self.loop_duration:
+                self.reset_loop()
 
     # ------------------------------------------------------------------
-    # Execution
+    # Internal helpers
     # ------------------------------------------------------------------
-    def _execute(self, event: TimelineEvent) -> None:
-        if event.action == "set_flag" and event.flag:
-            self.state.set_flag(event.flag, True)
-            self.state.save()
+    def _sync_ticks(self, current_ticks: int) -> None:
+        if self._last_tick == 0:
+            delta = current_ticks
+            self._last_tick = current_ticks
+            self.elapsed_time += delta / 1000.0
+            return
+        delta = current_ticks - self._last_tick
+        if delta < 0:
+            delta = 0
+        self.elapsed_time += delta / 1000.0
+        self._last_tick = current_ticks
+
+    # ------------------------------------------------------------------
+    # Execution and loop handling
+    # ------------------------------------------------------------------
+    def trigger_event(self, event: TimelineEvent) -> None:
+        event.execute(self.game_state, self.scene_manager)
+
+    def reset_loop(self) -> None:
+        self.elapsed_time = 0.0
+        self._last_tick = 0
+        for ev in self.events:
+            ev.triggered = False
+            ev.scheduled_at = 0.0

--- a/tests/test_timeline_engine.py
+++ b/tests/test_timeline_engine.py
@@ -7,12 +7,18 @@ from engine.timeline_engine import TimelineEngine
 from engine.game_state import GameState
 
 
-def test_delay_event_triggers(tmp_path):
-    state = GameState(save_path=str(tmp_path / "save.json"))
+def test_delay_event_triggers():
+    state = GameState()
     engine = TimelineEngine(state)
-    engine.add_events([
-        {"trigger": "delay", "time": 1, "action": "set_flag", "flag": "door"}
-    ], current_ticks=0)
+    engine.load_events([
+        {
+            "id": "door_event",
+            "trigger": "delay",
+            "time": 1.0,
+            "action": "set_flag",
+            "params": {"flag": "door"},
+        }
+    ])
 
     engine.update(current_ticks=500)
     assert state.get_flag("door") is False
@@ -21,15 +27,48 @@ def test_delay_event_triggers(tmp_path):
     assert state.get_flag("door") is True
 
 
-def test_scene_local_event(tmp_path):
+def test_condition_event(tmp_path):
     state = GameState(save_path=str(tmp_path / "save.json"))
     engine = TimelineEngine(state)
-    engine.add_events([
-        {"trigger": "delay", "time": 1, "action": "set_flag", "flag": "door"}
-    ], current_ticks=0, scene="intro")
+    engine.load_events([
+        {
+            "id": "gate",
+            "trigger": "condition",
+            "time": 0.2,
+            "condition": "open",
+            "action": "set_flag",
+            "params": {"flag": "gate"},
+        }
+    ])
 
-    engine.update(current_ticks=1500, current_scene="other")
-    assert state.get_flag("door") is False
+    engine.update(current_ticks=300)
+    assert state.get_flag("gate") is False
 
-    engine.update(current_ticks=1500, current_scene="intro")
+    state.set_flag("open", True)
+    engine.update(current_ticks=600)
+    assert state.get_flag("gate") is True
+
+
+def test_time_loop_resets():
+    state = GameState()
+    engine = TimelineEngine(state)
+    engine.loop_enabled = True
+    engine.loop_duration = 2.0
+    engine.load_events([
+        {
+            "id": "toggle",
+            "trigger": "delay",
+            "time": 1.0,
+            "action": "toggle_flag",
+            "params": {"flag": "door"},
+        }
+    ])
+
+    engine.update(current_ticks=1100)
     assert state.get_flag("door") is True
+
+    engine.update(current_ticks=2100)
+    assert engine.elapsed_time < 0.1
+
+    engine.update(current_ticks=1200 + 2100)  # another second after reset
+    assert state.get_flag("door") is False


### PR DESCRIPTION
## Summary
- overhaul timeline_engine with TimelineEvent dataclass
- support time loops, condition triggers, and scene actions
- update tests for new interface and loop behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687304145c6c8322bd24ccf4be9809f2