### PR TITLE
Add modular YAML puzzle types

### DIFF
--- a/engine/puzzle_manager.py
+++ b/engine/puzzle_manager.py
@@ -36,6 +36,10 @@ class PuzzleManager:
         """Load puzzle registry from ``path``."""
         self.engine.load_file(path)
 
+    def load_from_yaml(self, scene_id: str, data: dict) -> None:
+        """Load puzzle definitions from parsed YAML ``data``."""
+        self.engine.load_from_yaml(scene_id, data)
+
     # ------------------------------------------------------------------
     # Activation
     # ------------------------------------------------------------------
@@ -69,3 +73,7 @@ class PuzzleManager:
     def update(self) -> None:
         if self.active:
             self.active.update()
+
+    def check(self, puzzle_id: str, player_input) -> bool:
+        """Validate ``player_input`` for puzzle and mark solved if correct."""
+        return self.engine.check(puzzle_id, player_input)

--- a/engine/puzzle_types/__init__.py
+++ b/engine/puzzle_types/__init__.py
@@ -1,0 +1,21 @@
+"""Built-in puzzle type registry."""
+from importlib import import_module
+from pathlib import Path
+from typing import Dict, Type
+
+from ..puzzle_engine import PuzzleBase
+
+
+def load_types() -> Dict[str, Type[PuzzleBase]]:
+    """Dynamically import puzzle type modules and return a registry."""
+    registry: Dict[str, Type[PuzzleBase]] = {}
+    pkg_path = Path(__file__).parent
+    for py in pkg_path.glob("*.py"):
+        if py.stem.startswith("_") or py.stem == "__init__":
+            continue
+        module = import_module(f"engine.puzzle_types.{py.stem}")
+        cls = getattr(module, "PuzzleType", None)
+        name = getattr(module, "PUZZLE_TYPE", py.stem)
+        if cls:
+            registry[name] = cls
+    return registry

--- a/engine/puzzle_types/lockbox.py
+++ b/engine/puzzle_types/lockbox.py
@@ -1,0 +1,15 @@
+"""Simple lockbox puzzle type."""
+from ..puzzle_engine import PuzzleBase
+
+PUZZLE_TYPE = "lockbox"
+
+
+class PuzzleType(PuzzleBase):
+    """A numeric lock that opens with the correct code."""
+
+    def check_solution(self, player_input):
+        code = str(self.meta.solution or self.meta.data.get("code", ""))
+        if str(player_input) == code:
+            self.mark_solved()
+            return True
+        return False

--- a/engine/puzzle_types/match_items.py
+++ b/engine/puzzle_types/match_items.py
@@ -1,0 +1,15 @@
+"""Item matching puzzle."""
+from ..puzzle_engine import PuzzleBase
+
+PUZZLE_TYPE = "match_items"
+
+
+class PuzzleType(PuzzleBase):
+    """Match items to their correct slots."""
+
+    def check_solution(self, player_input):
+        expected = self.meta.solution or self.meta.data.get("matches", {})
+        if player_input == expected:
+            self.mark_solved()
+            return True
+        return False

--- a/engine/puzzle_types/sequence.py
+++ b/engine/puzzle_types/sequence.py
@@ -1,0 +1,15 @@
+"""Sequence puzzle type."""
+from ..puzzle_engine import PuzzleBase
+
+PUZZLE_TYPE = "sequence"
+
+
+class PuzzleType(PuzzleBase):
+    """Validate a sequence of inputs."""
+
+    def check_solution(self, player_input):
+        expected = self.meta.solution or self.meta.data.get("sequence", [])
+        if player_input == expected:
+            self.mark_solved()
+            return True
+        return False


### PR DESCRIPTION
## Summary
- expand `PuzzleMeta` to include `solution` and generalized `on_solve`
- load puzzle type modules from `engine/puzzle_types`
- support loading puzzles from scene YAML via `load_from_yaml`
- add `check_solution` flow and new puzzle types: lockbox, sequence, match_items
- expose helper methods on `PuzzleManager`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873213892e4832295f5036f715e3a1a